### PR TITLE
Support empty lifecycle rules for s3-archive-bucket

### DIFF
--- a/modules/s3-archive-bucket/lifecycle.tf
+++ b/modules/s3-archive-bucket/lifecycle.tf
@@ -35,6 +35,8 @@ resource "aws_s3_bucket_versioning" "this" {
 
 # TODO: `expected_bucket_owner`
 resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count = length(var.lifecycle_rules) > 0 ? 1 : 0
+
   bucket = aws_s3_bucket.this.bucket
 
   dynamic "rule" {

--- a/modules/s3-archive-bucket/outputs.tf
+++ b/modules/s3-archive-bucket/outputs.tf
@@ -50,7 +50,7 @@ output "versioning" {
 output "lifecycle_rules" {
   description = "The lifecycle configuration for the bucket."
   value = {
-    for rule in aws_s3_bucket_lifecycle_configuration.this.rule :
+    for rule in try(aws_s3_bucket_lifecycle_configuration.this[0].rule, []) :
     rule.id => {
       id      = rule.id
       enabled = rule.status == "Enabled"


### PR DESCRIPTION
### Background

- Fix to support empty `lifecycle_rules` for `s3-archive-bucket`