### PR TITLE
Fix bucket policy of s3-archive-bucket module for elb logging

### DIFF
--- a/modules/s3-archive-bucket/policies.tf
+++ b/modules/s3-archive-bucket/policies.tf
@@ -35,8 +35,8 @@ locals {
   elb_resources = [
     for prefix in local.elb_key_prefixes :
     prefix != ""
-    ? "${aws_s3_bucket.this.arn}/${prefix}/AWSLogs/*/elasticloadbalancing/*"
-    : "${aws_s3_bucket.this.arn}/AWSLogs/*/elasticloadbalancing/*"
+    ? "${aws_s3_bucket.this.arn}/${prefix}/AWSLogs/*"
+    : "${aws_s3_bucket.this.arn}/AWSLogs/*"
   ]
 }
 


### PR DESCRIPTION
### Background

- Cannot create test file for log delivery by ELB service.