### PR TITLE
Support SASL/SCRAM for msk-cluster module

### DIFF
--- a/modules/msk-cluster/cluster.tf
+++ b/modules/msk-cluster/cluster.tf
@@ -19,12 +19,20 @@ locals {
 # Configuration for MSK Cluster
 ###################################################
 
+locals {
+  server_properties = <<EOT
+%{for k, v in var.kafka_server_properties~}
+${k} = ${v}
+%{endfor~}
+EOT
+}
+
 resource "aws_msk_configuration" "this" {
   name           = var.name
   description    = "Configuration for ${var.name} Kafka Cluster."
   kafka_versions = [var.kafka_version]
 
-  server_properties = var.kafka_server_properties
+  server_properties = local.server_properties
 
   lifecycle {
     create_before_destroy = true
@@ -37,7 +45,6 @@ resource "aws_msk_configuration" "this" {
 ###################################################
 
 # TODO: public access cidrs
-# TODO: server_properties with map
 resource "aws_msk_cluster" "this" {
   cluster_name           = var.name
   kafka_version          = var.kafka_version

--- a/modules/msk-cluster/outputs.tf
+++ b/modules/msk-cluster/outputs.tf
@@ -75,8 +75,14 @@ output "auth" {
       enabled = aws_msk_cluster.this.client_authentication.0.unauthenticated
     }
     sasl = {
-      iam_enabled   = aws_msk_cluster.this.client_authentication.0.sasl.0.iam
-      scram_enabled = aws_msk_cluster.this.client_authentication.0.sasl.0.scram
+      iam = {
+        enabled = aws_msk_cluster.this.client_authentication.0.sasl.0.iam
+      }
+      scram = {
+        enabled = aws_msk_cluster.this.client_authentication.0.sasl.0.scram
+        kms_key = var.auth_sasl_scram_kms_key
+        users   = var.auth_sasl_scram_users
+      }
     }
     tls = {
       enabled     = var.auth_tls_enabled

--- a/modules/msk-cluster/scram-secrets.tf
+++ b/modules/msk-cluster/scram-secrets.tf
@@ -1,0 +1,55 @@
+resource "random_password" "this" {
+  for_each = var.auth_sasl_scram_users
+
+  length = 16
+
+  min_lower   = 2
+  min_upper   = 1
+  min_numeric = 2
+  min_special = 1
+
+  override_special = "!#$%&*()-=<>:"
+}
+
+
+###################################################
+# SASL/SCRAM User & Password for MSK Cluster
+###################################################
+
+# TODO: Create an independant module for msk-scram-users
+module "secret" {
+  source  = "tedilabs/secret/aws//modules/secrets-manager-secret"
+  version = "~> 0.2.0"
+
+  for_each = var.auth_sasl_scram_users
+
+  name        = "AmazonMSK_SCRAM/${var.name}/${each.key}"
+  description = "The SASL/SCRAM secret to provide username and password for MSK cluster authenticaiton."
+
+  type = "KEY_VALUE"
+  value = {
+    username = each.key
+    password = random_password.this[each.key].result
+  }
+
+  kms_key             = var.auth_sasl_scram_kms_key
+  policy              = null
+  block_public_policy = true
+
+  deletion_window_in_days = 7
+
+  resource_group_enabled = false
+  module_tags_enabled    = false
+
+  tags = merge(
+    local.module_tags,
+    var.tags,
+  )
+}
+
+resource "aws_msk_scram_secret_association" "this" {
+  count = length(module.secret) > 0 ? 1 : 0
+
+  cluster_arn     = aws_msk_cluster.this.arn
+  secret_arn_list = values(module.secret).*.arn
+}

--- a/modules/msk-cluster/variables.tf
+++ b/modules/msk-cluster/variables.tf
@@ -12,8 +12,9 @@ variable "kafka_version" {
 
 variable "kafka_server_properties" {
   description = "(Optional) Contents of the `server.properties` file for configuration of Kafka."
-  type        = string
-  default     = ""
+  type        = map(string)
+  default     = {}
+  nullable    = false
 }
 
 variable "broker_size" {
@@ -98,6 +99,19 @@ variable "auth_sasl_scram_enabled" {
   description = "(Optional) Enables SCRAM client authentication via AWS Secrets Manager."
   type        = bool
   default     = false
+  nullable    = false
+}
+
+variable "auth_sasl_scram_kms_key" {
+  description = "(Optional) The ARN of a KMS key to encrypt AWS SeecretsManager Secret resources for storing SASL/SCRAM authentication data. Only required when the MSK cluster has SASL/SCRAM authentication enabled. The Username/Password Authentication based on SASL/SCRAM needs to create a Secret resource in AWS SecretsManager with a custom AWS KMS Key. A secret created with the default AWS KMS key cannot be used with an Amazon MSK cluster."
+  type        = string
+  default     = null
+}
+
+variable "auth_sasl_scram_users" {
+  description = "(Optional) A list of usernames to be allowed for SASL/SCRAM authentication to the MSK cluster. The password for each username is randomly generated and stored in AWS SecretsManager secret."
+  type        = set(string)
+  default     = []
   nullable    = false
 }
 

--- a/modules/msk-cluster/versions.tf
+++ b/modules/msk-cluster/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.22"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.3"
+    }
   }
 }


### PR DESCRIPTION
### Background

- Support SASL/SCRAM authentication for `msk-cluster` module
- Configure `kafka_server_properties` with `map(string)` instead of `string` in `msk-cluster` module